### PR TITLE
Create a fake 'white' to prevent Prince making white transparent

### DIFF
--- a/_sass/custom/_colours.scss
+++ b/_sass/custom/_colours.scss
@@ -7,6 +7,7 @@
 //     Section 4: orange/yellow
 //     Section 5: red
 
+$white: #fff;
 $black-10: #e1e0dc; // cmyk(4%, 3%, 6%, 7%)
 $black-30: #c6cacb; // cmyk(22%, 15%, 16%, 0%)
 $black-50: #abb1b3; // cmyk(34%, 24%, 25%, 0%)
@@ -44,6 +45,7 @@ $lightlightgrey: $black-10;
 // CYMK values for print output
 @if $output-format == "print-pdf" {
     
+    $white: cmyk(0%, 0%, 0%, 1%); // to avoid not printing
     $black-10: cmyk(4%, 3%, 6%, 7%); // #e1e0dc
     $black-30: cmyk(22%, 15%, 16%, 0%); // #c6cacb
     $black-50: cmyk(34%, 24%, 25%, 0%); // #abb1b3

--- a/_sass/custom/_pdf-tools.scss
+++ b/_sass/custom/_pdf-tools.scss
@@ -31,7 +31,7 @@
     h1 {
         &.icon-users {
             &::before {
-                @include icon-users(white, $line-height-default * 3);
+                @include icon-users($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -42,7 +42,7 @@
     h1 {
         &.icon-search {
             &::before {
-                @include icon-search(white, $line-height-default * 3);
+                @include icon-search($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -53,7 +53,7 @@
     h1 {
         &.icon-map {
             &::before {
-                @include icon-map(white, $line-height-default * 3);
+                @include icon-map($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -64,7 +64,7 @@
     h1 {
         &.icon-scale {
             &::before {
-                @include icon-scale(white, $line-height-default * 3);
+                @include icon-scale($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -75,7 +75,7 @@
     h1 {
         &.icon-injury {
             &::before {
-                @include icon-injury(white, $line-height-default * 3);
+                @include icon-injury($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -86,7 +86,7 @@
     h1 {
         &.icon-list {
             &::before {
-                @include icon-list(white, $line-height-default * 3);
+                @include icon-list($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -97,7 +97,7 @@
     h1 {
         &.icon-paintbrush {
             &::before {
-                @include icon-paintbrush(white, $line-height-default * 3);
+                @include icon-paintbrush($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -108,7 +108,7 @@
     h1 {
         &.icon-calendar {
             &::before {
-                @include icon-calendar(white, $line-height-default * 3);
+                @include icon-calendar($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -119,7 +119,7 @@
     h1 {
         &.icon-tick {
             &::before {
-                @include icon-tick(white, $line-height-default * 3);
+                @include icon-tick($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -130,7 +130,7 @@
     h1 {
         &.icon-puzzle {
             &::before {
-                @include icon-puzzle(white, $line-height-default * 3);
+                @include icon-puzzle($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -141,7 +141,7 @@
     h1 {
         &.icon-pencil {
             &::before {
-                @include icon-pencil(white, $line-height-default * 3);
+                @include icon-pencil($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }
@@ -152,7 +152,7 @@
     h1 {
         &.icon-clipboard {
             &::before {
-                @include icon-clipboard(white, $line-height-default * 3);
+                @include icon-clipboard($white, $line-height-default * 3);
                 @include tool-icon-styles();
             }
         }


### PR DESCRIPTION
@LaurenEllwood This addresses one of the issues in #7. @LouiseSteward, you may be curious to see this one, too. Could either of you glance and merge, please?

I think that to Prince 'white' is the paper colour, so it's transparent. But on a grey background, when Prince applies PDF X1a and removes transparency, that white/transparent disappears. (This doesn't happen in screen PDF because there we use PDF A-3b, which allows transparency and uses an RGB colorspace.)

To prevent this, I've created a colour called $white that's actually just 1% black, and used it for icons on grey. The 1% black should not be visible when printed.