### PR TITLE
Live config deploy

### DIFF
--- a/_configs/_config.live.yml
+++ b/_configs/_config.live.yml
@@ -5,8 +5,8 @@
 build: live
 
 # URLs
-canonical-url: "http://example.com"
-baseurl: "/example"
+canonical-url: "https://natural-playgrounds-toolkit.ready4school.info"
+baseurl: ""
 
 # Exclude list
 exclude: [

--- a/_includes/close-body.html
+++ b/_includes/close-body.html
@@ -13,5 +13,8 @@
 {% include end-elements %}
 
 </div><!--#wrapper-->
+
+<!-- This {{ site.build }} build was created at {{ site.time | date: "%Y-%m-%d %H:%M" }} -->
+
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,9 +18,9 @@
 
 # Default build settings
 [build]
-  command = jekyll build --baseurl=""
+  command = "jekyll build --baseurl=''"
 
 # Build the master branch with the live config.
 # This more specific rule overrides the default build command above.
 [context.master]
-  command = jekyll build --config="_config.yml, _configs/_config.live.yml"
+  command = "jekyll build --config='_config.yml, _configs/_config.live.yml'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,8 @@
 # Jekyll does not build files that start with underscores.
 # https://docs.netlify.com/configure-builds/file-based-configuration/#redirects
 
+# Redirect various domains to the canonical domain
+# The order of these redirects matters.
 [[redirects]]
   from = "https://natpg.ready4school.info/*"
   to = "https://natural-playgrounds-toolkit.ready4school.info/:splat"
@@ -13,3 +15,12 @@
   to = "https://natural-playgrounds-toolkit.ready4school.info/:splat"
   status = 301
   force = true
+
+# Default build settings
+[build]
+  command = jekyll build --baseurl=""
+
+# Build the master branch with the live config.
+# This more specific rule overrides the default build command above.
+[context.master]
+  command = jekyll build --config="_config.yml, _configs/_config.live.yml"


### PR DESCRIPTION
This should tell Netlify to build the master branch with the live config, and to use the default config only for other builds. It adds an HTML comment to page builds that we can inspect to tell whether a build is live or not. If a build is live, the comment after the `<body>` element should read `This live build was created at 2019-11-30 11:11`, where the time is the time of the build. A non-live build will just say ` This build was created`.