### PR TITLE
Base URL and docs for staging sites

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,7 +85,7 @@ mathjax-enabled: false
 #            across books in this project.
 collections:
   docs:
-    output: false
+    output: true
   items:
     output: false
 

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ canonical-url: "https://natural-playgrounds-toolkit.ready4school.info"
 # the name of your repo, e.g. /electric-book
 # It must start with a slash. Otherwise you can leave it blank. See:
 # http://downtothewire.io/2015/08/15/configuring-jekyll-for-user-and-project-github-pages/
-baseurl: ""
+baseurl: "/rff-natural-playgrounds"
 
 # GitHub Pages repository
 # -----------------------


### PR DESCRIPTION
This adds a base URL to the default (non-`live`) config, and turns on the docs there, so that we get a GitHub Pages staging site for free that includes docs. 

Since the `live` config turns off the docs and the `baseurl`, the live site published by Netlify remains unaffected. 

@LaurenEllwood @LouiseSteward I'm merging this now and will test myself, so that I can fix or revert it now before people start using the site too much.